### PR TITLE
兼容0.2.8及以前版本的订阅不失效

### DIFF
--- a/server/router/router_public.go
+++ b/server/router/router_public.go
@@ -26,6 +26,7 @@ func (g *GinRouter) InitPublicRouter(r *gin.RouterGroup) {
 	// 订阅
 	subRouter := publicRouter.Group("/sub").Use(middleware.RateLimitIP())
 	{
+		subRouter.GET("/:id", public_api.GetSub)
 		subRouter.GET("/:id/:name", public_api.GetSub)
 	}
 	// user


### PR DESCRIPTION
route_public.go中添加了一条路由
`subRouter.GET("/:id", public_api.GetSub)`
兼容以前版本的订阅